### PR TITLE
cron: do not run pfl via cron if the systemd pfl.timer is enabled

### DIFF
--- a/cron/pfl
+++ b/cron/pfl
@@ -1,2 +1,8 @@
 #!/bin/sh
+
+if [ -e /bin/systemctl ] && /bin/systemctl is-enabled --quiet pfl.timer; then
+	# Do not run pfl via cron if the respective systemd timer is enabled.
+	exit
+fi
+
 setpriv --reuid=portage --regid=portage --clear-groups nice /usr/bin/pfl >/dev/null


### PR DESCRIPTION
On Gentoo systems where the pfl systemd timer is enabled and having a
cron compatilibitly layer installed, e.g. sys-process/systemd-cron,
pfl would actually be invoked *twice* per week.

This changes the /etc/cron.weekly/pfl script to not run pfl if the
pfl.timer is enabled, since systemd timers are preferable over
/etc/cron.* tasks, because systemd has more knowledge about existing
timers and features like RandomizedDelaySec.