### PR TITLE
Run pfl.service as user portage

### DIFF
--- a/systemd/pfl.service
+++ b/systemd/pfl.service
@@ -4,6 +4,8 @@ After=network.target
 
 [Service]
 Type=oneshot
+User=portage
+Group=portage
 ExecStart=/usr/bin/pfl
 
 [Install]


### PR DESCRIPTION
Hello,

Before this commit pfl.service is executed as root and this prevents pfl.service from starting successfully because environment variables such as $HOME is not automatically exposed to services managed by systemd. Because of this the following error occurs:
```
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.8/pfl", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python-exec/python3.8/pfl", line 7, in main
    pfl.pfl.PFL().run()
  File "/usr/lib/python3.8/site-packages/pfl/pfl.py", line 227, in run
    self._finish(xmlfile, True)
  File "/usr/lib/python3.8/site-packages/pfl/pfl.py", line 174, in _finish
    hconfig = open(INFOFILE, 'w')
FileNotFoundError: [Errno 2] No such file or directory: 'None/.pfl.info'
 pfl.service: Main process exited, code=exited, status=1/FAILURE
 pfl.service: Failed with result 'exit-code'.
 Failed to start Portage File List upload.
```
This happens because user is not portage and therefore $HOME is used which is not set. This commit changes the user running the service to portage instead, aligning it with the cron job.