### PR TITLE
Use EROOT for determining root

### DIFF
--- a/bin/e-file
+++ b/bin/e-file
@@ -66,8 +66,9 @@ elif 'result' in resultJson:
                 cps[category][package]['versions'].append(version)
                 cps[category][package]['files'].append(filepath)
 
-        vardbapi = portage.db['/']['vartree'].dbapi
-        portdbapi = portage.db['/']['porttree'].dbapi
+        eroot = portage.settings['EROOT']
+        vardbapi = portage.db[eroot]['vartree'].dbapi
+        portdbapi = portage.db[eroot]['porttree'].dbapi
         for category, packages in cps.items():
             for package, vf in packages.items():
                 installed_cpvs = sorted(set(vardbapi.cp_list('%s/%s' % (category, package))))

--- a/pfl/pfl.py
+++ b/pfl/pfl.py
@@ -49,11 +49,12 @@ class PortageMangle(object):
     _xmlfile = None
 
     def __init__(self):
-        if '/' in portage.db:
-            self._settings = portage.db['/']['vartree'].settings
-            self._vardbapi = portage.db['/']['vartree'].dbapi
+        eroot = portage.settings['EROOT']
+        if eroot in portage.db:
+            self._settings = portage.db[eroot]['vartree'].settings
+            self._vardbapi = portage.db[eroot]['vartree'].dbapi
         else:
-            raise Exception('Tree "/" not present.')
+            raise Exception(f'Tree "{eroot}" not present.')
 
     def get_wellknown_cpvs(self, since):
         # category, package, version of all installed packages


### PR DESCRIPTION
* Allows correct behaviour on prefixed installs like in virtualenv or on Gentoo prefix.

```
ask@lane ~/sources/client $ python -m venv ~/venv/pfl    
                                                           
ask@lane ~/sources/client $ source ~/venv/pfl/bin/activate               
                                           
(pfl) ask@lane ~/sources/client $ pip install .                                                                     
Processing /home/ask/sources/client                                                                                 
  Installing build dependencies ... done                                                                            
  Getting requirements to build wheel ... done                                                                      
  Preparing metadata (pyproject.toml) ... done                                                                      
Building wheels for collected packages: pfl                                                                         
  Building wheel for pfl (pyproject.toml) ... done                                                                  
  Created wheel for pfl: filename=pfl-3.2.1-py3-none-any.whl size=6577 sha256=e86ae7a314c8ec37cacc56c93328c15e8dcda040f4e07d7062a86f44a31c92a1
  Stored in directory: /tmp/pip-ephem-wheel-cache-539n4a7x/wheels/a5/f6/d7/9fda48587f273cc2e6f8b8327cb616a3a2066b97c9e489e6ef
Successfully built pfl                                                                                              
Installing collected packages: pfl                                                                                  
Successfully installed pfl-3.2.1               
                                                                     
(pfl) ask@lane ~/sources/client $ pip install portage requests termcolor
<snip>

(pfl) ask@lane ~/sources/client $ type -P e-file
/home/ask/venv/pfl/bin/e-file
(pfl) ask@lane ~/sources/client $ e-file pfl
Traceback (most recent call last):
  File "/home/ask/venv/pfl/bin/e-file", line 69, in <module>
    vardbapi = portage.db['/']['vartree'].dbapi
               ~~~~~~~~~~^^^^^
  File "/home/ask/venv/pfl/lib/python3.12/site-packages/portage/proxy/objectproxy.py", line 45, in __getitem__
    return object.__getattribute__(self, "_get_target")()[key]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
KeyError: '/'

(pfl) ask@lane ~/sources/client $ git checkout -B eroot remotes/origin/eroot
branch 'eroot' set up to track 'origin/eroot'.
Switched to a new branch 'eroot'

(pfl) ask@lane ~/sources/client $ pip install .
Processing /home/ask/sources/client
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: pfl
  Building wheel for pfl (pyproject.toml) ... done
  Created wheel for pfl: filename=pfl-3.2.1-py3-none-any.whl size=6613 sha256=a8bbafad73e88cc7eb1ffc955620c50bb69e8c545b172dc360a7f90f2aba2253
  Stored in directory: /tmp/pip-ephem-wheel-cache-kq6huxro/wheels/a5/f6/d7/9fda48587f273cc2e6f8b8327cb616a3a2066b97c9e489e6ef
Successfully built pfl
Installing collected packages: pfl
  Attempting uninstall: pfl
    Found existing installation: pfl 3.2.1
    Uninstalling pfl-3.2.1:
      Successfully uninstalled pfl-3.2.1
Successfully installed pfl-3.2.1

(pfl) ask@lane ~/sources/client $ e-file pfl
 *  app-portage/pfl
        Seen Versions:          3.2.1
        Portage Versions:       3.2.1 
        Homepage:               http://www.portagefilelist.de https://github.com/portagefilelist/client
        Description:            Searchable online file/package database for Gentoo
        Matched Files:          /etc/cron.weekly/pfl; /usr/bin/pfl; /usr/lib/python-exec/python3.10/pfl; /usr/lib/python-exec/python3.11/pfl
```