### PR TITLE
bin/e-file: Use fromtimestamp instead of utcfromtimestamp

### DIFF
--- a/bin/e-file
+++ b/bin/e-file
@@ -113,7 +113,7 @@ elif 'result' in resultJson:
                             build_time = 0
 
                         sys.stdout.write(colored(portage.versions.cpv_getversion(installed_cpv), 'grey', 'on_blue'))
-                        sys.stdout.write(colored(datetime.utcfromtimestamp(build_time).strftime('(%c) '), 'magenta'))
+                        sys.stdout.write(colored(datetime.fromtimestamp(build_time).strftime('(%c) '), 'magenta'))
 
                     sys.stdout.write('\n')
 


### PR DESCRIPTION
* Deprecated in python3.12.
* Being timezone aware would be useful here so not specifying UTC again.