### PR TITLE
fix incorrect info in man pages

### DIFF
--- a/man/e-file.1
+++ b/man/e-file.1
@@ -20,15 +20,3 @@ Show this help message and exit.
 .TP
 \fB\-v\fR, \fB\-\-version\fR
 Show program's version number and exit.
-.SH "SEE ALSO"
-The full documentation for
-.B e-file
-is maintained as a Texinfo manual.  If the
-.B info
-and
-.B e-file
-programs are properly installed at your site, the command
-.IP
-.B info e-file
-.PP
-should give you access to the complete manual.

--- a/man/pfl.1
+++ b/man/pfl.1
@@ -28,15 +28,3 @@ Show this help message and exit.
 .TP
 \fB\-v\fR, \fB\-\-version\fR
 Show version number and exit.
-.SH "SEE ALSO"
-The full documentation for
-.B pfl
-is maintained as a Texinfo manual.  If the
-.B info
-and
-.B pfl
-programs are properly installed at your site, the command
-.IP
-.B info pfl
-.PP
-should give you access to the complete manual.


### PR DESCRIPTION
If you tried reading the man pages, it told you that the manpages are NOT the correct way to read the documentation, and recommended using installing emacs and then using the emacs-specific "info" pages, or alternatively the half-baked "info" command that doesn't really work properly.

But, there are no texinfo pages for pfl which makes the whole thing quite weird.