### PR TITLE
e-file: copy "Seen Versions" approach to "Portage Versions"

### DIFF
--- a/pfl/e_file.py
+++ b/pfl/e_file.py
@@ -103,10 +103,7 @@ class Efile(object):
                     self.log(colored('\tSeen Versions:'.ljust(22), 'green') + '%s' % ' '.join(versions))
 
                     #        Portage Versions:       X.Y A.B
-                    _toPrint = colored('\tPortage Versions:'.ljust(22), 'green')
-                    for available_cpv in available_cpvs:
-                        _toPrint += portage.versions.cpv_getversion(available_cpv)
-                    self.log(_toPrint)
+                    self.log(colored('\tPortage Versions:'.ljust(22), 'green') + '%s' % ' '.join(portage.versions.cpv_getversion(available_cpv)))
 
                     #        Repository:             Name
                     self.log(colored('\tRepository:'.ljust(22), 'green') + repo)


### PR DESCRIPTION
* This fixes the lack of whitespace with listed versions.

Before:
```
$ e-file systemd-journald
 *  sys-apps/systemd
        Seen Versions:       253.6 254.10 254.5 254.5-r1 254.6 254.7 254.7-r1 254.8 254.8-r1 254.9 255-r1 255.1 255.2 255.2-r1 255.2-r2 255.3 255.3-r1 255.4 255_rc2 255_rc4
        Portage Versions:    254.10254.8-r1254.9-r1255.3-r1255.49999
        Repository:          gentoo
        Homepage:            http://systemd.io/
        Description:         System and service manager for Linux
        Matched Files:       /lib/systemd/systemd-journald; /usr/lib/systemd/systemd-journald

```

After:
```
e-file systemd-journald
 *  sys-apps/systemd
        Seen Versions:          253.6 254.10 254.5 254.5-r1 254.6 254.7 254.7-r1 254.8 254.8-r1 254.9 255-r1 255.1 255.2 255.2-r1 255.2-r2 255.3 255.3-r1 255.4 255_rc2 255_rc4
        Portage Versions:       254.10 254.8-r1 254.9-r1 255.3-r1 255.4 9999 
        Repository:             gentoo
        Homepage:               http://systemd.io/
        Description:            System and service manager for Linux
        Matched Files:          /lib/systemd/systemd-journald; /usr/lib/systemd/systemd-journald
```