### PR TITLE
pfl.service: use (After|Wants)=network-online.target

### DIFF
--- a/systemd/pfl.service
+++ b/systemd/pfl.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Portage File List upload
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
pfl requires a network connection to submit its result, therefore we should wait for one to become available.

See also
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/